### PR TITLE
[fix] cluster-roll payload not wrapped properly

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -974,7 +974,7 @@ module.exports.rollCluster = function (obj) {
       'Authorization': 'Bearer ' + obj.token,
       'User-Agent':    module.exports.getUserAgent()
     },
-    json:    obj.updatePolicy.rollConfig
+    json:    {'roll': obj.updatePolicy.rollConfig}
   };
 
   console.log("rolling ocean cluster: " + JSON.stringify(rollOceanOptions, null, 2));

--- a/lib/util.js
+++ b/lib/util.js
@@ -159,8 +159,8 @@ function addNulls(oldConfig, newConfig) {
   diff.observableDiff(oldConfig, patchConfig, function (d) {
     if (d.kind === "D") {
       var isPropertyInArray = isPathIncludeNumber(d.path)
-      
-      if(isPropertyInArray == false) {
+
+      if (isPropertyInArray == false) {
         var patch = new Object();
         Object.defineProperty(patch, "kind", {
           value:      "N",
@@ -174,7 +174,7 @@ function addNulls(oldConfig, newConfig) {
           value:      null,
           enumerable: true
         });
-    
+
         diff.applyChange(patchConfig, oldConfig, patch);
       }
     }
@@ -185,14 +185,14 @@ function addNulls(oldConfig, newConfig) {
 
 function isPathIncludeNumber(path) {
   var retVal = false;
-  
-  for(let i = 0; i < path.length; i++) {
-    if(typeof path[i] == 'number') {
+
+  for (let i = 0; i < path.length; i++) {
+    if (typeof path[i] == 'number') {
       retVal = true;
       break;
     }
   }
-  
+
   return retVal;
 }
 
@@ -362,7 +362,7 @@ module.exports.parseBoolean = function (str) {
 
 module.exports.getParameters = function (event) {
   let reqType = _.get(event, 'RequestType');
-  let params = (
+  let params  = (
     _.get(event, 'ResourceProperties.parameters') ||
     _.get(event, 'parameters')) ||
     _.get(event, 'OldResourceProperties.parameters');
@@ -377,7 +377,7 @@ module.exports.getParameters = function (event) {
 };
 
 module.exports.getAccountId = function (event) {
-  let accountId =  _.get(event, 'ResourceProperties.accountId') || _.get(event, 'accountId');
+  let accountId = _.get(event, 'ResourceProperties.accountId') || _.get(event, 'accountId');
   if (!accountId) {
     accountId = _.get(event, 'OldResourceProperties.accountId');
   }
@@ -974,7 +974,7 @@ module.exports.rollCluster = function (obj) {
       'Authorization': 'Bearer ' + obj.token,
       'User-Agent':    module.exports.getUserAgent()
     },
-    json:    {'roll': obj.updatePolicy.rollConfig}
+    json:    { 'roll': obj.updatePolicy.rollConfig }
   };
 
   console.log("rolling ocean cluster: " + JSON.stringify(rollOceanOptions, null, 2));

--- a/lib/util.js
+++ b/lib/util.js
@@ -700,18 +700,20 @@ module.exports.updateGroup = function (obj) {
  *   updatePolicy: updatePolicy, refId: refId, tc: tc, body: body}
  */
 module.exports.rollGroup = function (obj) {
-  let isEcsIntegration = _.get(obj, 'body.thirdPartiesIntegration.ecs');
   let url;
   let method;
+  let isEcsIntegration = _.get(obj, 'body.thirdPartiesIntegration.ecs');
+  let config           = obj.updatePolicy.rollConfig || {};
 
   if (isEcsIntegration) {
     url    = 'https://api.spotinst.io/aws/ec2/group/' + obj.refId + '/clusterRoll';
     method = 'POST';
-    console.log("group with ECS integration, preform cluster role");
+    config = Object.keys(config).length === 0 ? config : module.exports.wrap(config, "roll");
+    console.log("group with ECS integration, preform cluster roll");
   } else {
     url    = 'https://api.spotinst.io/aws/ec2/group/' + obj.refId + '/roll';
     method = 'PUT';
-    console.log("preform group role")
+    console.log("preform group roll")
   }
 
   let rollOptions = {
@@ -725,7 +727,7 @@ module.exports.rollGroup = function (obj) {
       'Authorization': 'Bearer ' + obj.token,
       'User-Agent':    module.exports.getUserAgent()
     },
-    json:    obj.updatePolicy.rollConfig || {}
+    json:    config,
   };
 
   console.log("rolling group: " + JSON.stringify(rollOptions, null, 2))
@@ -951,9 +953,9 @@ module.exports.validateOceanCluster = function (clusterId, token, event, context
  *   updatePolicy.rollConfig}
  */
 module.exports.rollCluster = function (obj) {
-
-  let resourceTypeCustom = _.get(obj, 'event.ResourceType');
   let url;
+  let resourceTypeCustom = _.get(obj, 'event.ResourceType');
+  let config             = obj.updatePolicy.rollConfig || {};
 
   if (resourceTypeCustom === "Custom::oceanEcs") {
     url = "https://api.spotinst.io/ocean/aws/ecs/cluster/" + obj.refId + "/roll";
@@ -974,7 +976,7 @@ module.exports.rollCluster = function (obj) {
       'Authorization': 'Bearer ' + obj.token,
       'User-Agent':    module.exports.getUserAgent()
     },
-    json:    { 'roll': obj.updatePolicy.rollConfig }
+    json:    Object.keys(config).length === 0 ? config : module.exports.wrap(config, "roll"),
   };
 
   console.log("rolling ocean cluster: " + JSON.stringify(rollOceanOptions, null, 2));
@@ -1002,6 +1004,17 @@ module.exports.rollCluster = function (obj) {
       }
     });
   })
+}
+
+/**
+ * Wraps an object with the specified wrapper.
+ *
+ * @param obj
+ * @param wrapper
+ * @returns {*}
+ */
+module.exports.wrap = function (obj, wrapper) {
+  return !wrapper || !obj || obj.hasOwnProperty(wrapper) ? obj : { [wrapper]: obj };
 }
 
 const defaultCfnResponderOptions = {

--- a/test/utils/featureflag.js
+++ b/test/utils/featureflag.js
@@ -30,8 +30,7 @@ describe("util featureFlag", () => {
 
     assert.deepStrictEqual(actual, expected);
   });
-
-
+  
   it("should return TestAlpha=false,TestBeta=true", () => {
     featureFlag.set("TestAlpha=false,TestBeta=true");
 

--- a/test/utils/wrap.js
+++ b/test/utils/wrap.js
@@ -1,0 +1,48 @@
+const assert   = require("assert");
+const { wrap } = require("../../lib/util");
+
+describe("util wrap", () => {
+
+  it("should return null (null wrapper)", () => {
+    const obj      = null;
+    const expected = null;
+    const actual   = wrap(obj, null);
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("should return null (data wrapper)", () => {
+    const obj      = null;
+    const expected = null;
+    const actual   = wrap(obj, "data");
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("should return the same object", () => {
+    const obj      = { data: { one: "two", key: "value" } };
+    const expected = { data: { one: "two", key: "value" } };
+    const actual   = wrap(obj, "data");
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("should return a wrapped object", () => {
+    const obj      = { one: "two", key: "value" };
+    const expected = { data: { one: "two", key: "value" } };
+    const actual   = wrap(obj, "data");
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("should return an empty wrapped object", () => {
+    const obj      = {};
+    const expected = { data: {} };
+    const actual   = wrap(obj, "data");
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("should return an empty unwrapped object", () => {
+    const obj      = {};
+    const expected = {};
+    const actual   = wrap(obj, null);
+    assert.deepStrictEqual(actual, expected);
+  });
+
+});


### PR DESCRIPTION
As per docs and optimizer, Ocean (k8s & ECS) rolls should be wrapped in "roll" object.

See: https://github.com/spotinst/spotinst-optimizer/blob/ffda0628b22201c2e6386c82601c36262b9ba3c0/controllers/ocean/roll.js#L13