### PR TITLE
[fix] Ocean Launch Specs: not properly handling rollback when creation fails

### DIFF
--- a/lib/resources/oceanEcsLaunchSpec/delete.js
+++ b/lib/resources/oceanEcsLaunchSpec/delete.js
@@ -59,6 +59,10 @@ let destroy = async function(err, event, context) {
 					}
 					console.log("Delete Ocean ECS launch spec Success: " + JSON.stringify(spotResponse, null, 2))
 					util.done(null, event, context, body);
+				},
+				failureCb: function(spotResponse) {
+					console.log("can't delete ocean ecs launch spec, checking if the cluster even exists");
+					spotUtil.validateOceanClusterLaunchSpec(spotResponse);
 				}
 			});
 		});

--- a/lib/resources/oceanLaunchSpec/delete.js
+++ b/lib/resources/oceanLaunchSpec/delete.js
@@ -59,6 +59,10 @@ let destroy = async function(err, event, context) {
 					}
 					console.log("Delete Ocean launch spec Success: " + JSON.stringify(spotResponse, null, 2))
 					util.done(null, event, context, body);
+				},
+				failureCb: function(spotResponse) {
+					console.log("can't delete ocean kubernetes launch spec, checking if the cluster even exists");
+					spotUtil.validateOceanClusterLaunchSpec(spotResponse);
 				}
 			});
 		});

--- a/lib/util.js
+++ b/lib/util.js
@@ -531,7 +531,7 @@ module.exports.createGroupFromImport = function (importedConfig, groupConfig, ev
 
 /**
  * This function is called when the destroy function fails. it checks if the
- * group exisists
+ * group exists
  *
  * @function
  * @name validateGroup
@@ -940,6 +940,50 @@ module.exports.validateOceanCluster = function (clusterId, token, event, context
     });
   });
 }
+
+
+/**
+ * This function is called when the DELETE call for ECS/K8s Launch Spec fails.
+ * It checks if the delete operation failed because the Launch Spec doesn't exist.
+ * If that's the case, it marks the (AWS) resource delete operation as successful.
+ *
+ * @function
+ * @name validateOceanClusterLaunchSpec
+ * @param {Object} response: The response received from the failed delete operation.
+ */
+module.exports.validateOceanClusterLaunchSpec = (response) => {
+  const { event, context, body, res } = response;
+  const defaultDone                   = [
+    `can't delete ocean launch spec, response body: ${body}`, event, context,
+  ];
+
+  if (res.statusCode === 404 || res.statusCode === 400) {
+    try {
+      const errors = _.get(JSON.parse(body), "response.errors", []);
+      if (errors.length > 0) {
+        const isReasonBecauseDoesNotExist = errors.some((error) => {
+          return error.code != null
+            && error.message != null
+            && (error.code === "CANT_DELETE_OCEAN_ECS_LAUNCH_SPEC" || error.code === "CANT_DELETE_OCEAN_LAUNCH_SPEC")
+            && error.message.includes("does not exist");
+        });
+
+        if (isReasonBecauseDoesNotExist) {
+          console.log("delete operation failed because the cluster launch spec doesn't exist, " +
+            "marking deletion as success");
+          util.done(null, event, context);
+          return;
+        } else {
+          console.log(`delete operation did NOT fail because the cluster launch spec doesn't exist, response body: ${body}`);
+        }
+      }
+    } catch (err) {
+      console.log(`can't determine deletion failure reason, error: ${err}`);
+    }
+  }
+
+  util.done(...defaultDone);
+};
 
 /**
  * This function rolls the Cluster. Used in update. currently for ECS Clusters

--- a/test/utils/validateOceanClusterLaunchSpec.js
+++ b/test/utils/validateOceanClusterLaunchSpec.js
@@ -1,0 +1,119 @@
+const assert  = require("assert");
+const utils   = require("../../lib/util");
+const utilSpy = require("lambda-formation").util;
+const nock    = require("nock");
+const sinon   = require("sinon");
+const _       = require("lodash");
+
+describe("util validateOceanClusterLaunchSpec", function () {
+  let sandbox, response = { res: { statusCode: 400 }, event: {}, context: {}, err: {} };
+
+  beforeEach(() => {
+    nock.cleanAll();
+    sandbox = sinon.createSandbox();
+  })
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should mark deletion as success if delete failed because ecs/launchspec doesn't exist", (done) => {
+    response.body = `{
+      "response": {
+        "errors": [
+          { "code": "CANT_DELETE_OCEAN_ECS_LAUNCH_SPEC",
+            "message": "does not exist"
+          }
+        ]
+      }
+    }`;
+
+
+    utilSpy.done = sandbox.spy((err) => {
+      assert.strictEqual(err, null);
+      done();
+    })
+
+    utils.validateOceanClusterLaunchSpec(response);
+  });
+
+  it("should mark deletion as success if delete failed because k8s/launchspec doesn't exist", (done) => {
+    response.body = `{
+      "response": {
+        "errors": [
+          { "code": "CANT_DELETE_OCEAN_LAUNCH_SPEC",
+            "message": "does not exist"
+          }
+        ]
+      }
+    }`;
+
+    utilSpy.done = sandbox.spy((err) => {
+      assert.strictEqual(err, null);
+      done();
+    })
+
+    utils.validateOceanClusterLaunchSpec(response);
+  });
+
+  it("should not mark deletion as success if deletion error message doesn't contain `does not exist`", (done) => {
+    response.body = `{
+      "response": {
+        "errors": [
+          { "code": "CANT_DELETE_OCEAN_LAUNCH_SPEC",
+            "message": "some other message"
+          }
+        ]
+      }
+    }`;
+
+    utilSpy.done = sandbox.spy((err) => {
+      assert.notStrictEqual(err, null);
+      assert(err.includes(response.body));
+      done();
+    })
+
+    utils.validateOceanClusterLaunchSpec(response);
+  });
+
+  it("should not mark deletion as success if response body isn't valid JSON", (done) => {
+    response.body = `
+      "response": {
+        "errors": [
+          { "code": "CANT_DELETE_OCEAN_LAUNCH_SPEC",
+            "message": "some other message"
+          }
+        ]
+      }
+    }`;
+
+    utilSpy.done = sandbox.spy((err) => {
+      assert.notStrictEqual(err, null);
+      assert(err.includes(response.body));
+      done();
+    })
+
+    utils.validateOceanClusterLaunchSpec(response);
+  });
+
+  it("should not mark deletion as success if body.errors.code is null", (done) => {
+    response.body = `{
+      "response": {
+        "errors": [
+          { "code": null,
+            "message": "some other message"
+          }
+        ]
+      }
+    }`;
+
+    utilSpy.done = sandbox.spy((err) => {
+      assert.notStrictEqual(err, null);
+      assert(err.includes(response.body));
+      done();
+    })
+
+    utils.validateOceanClusterLaunchSpec(response);
+  });
+
+});


### PR DESCRIPTION
When a creation of a stack fails, CFN issues a corresponding delete operation to clean up the resources and roll-back (delete) the resources.

This adds proper handling for this scenario: If the corresponding delete operation failed because Spot API indicates that the launch-spec does not exist, we mark the deletion operation as successful - letting the stack be reverted/deleted without user-intervention.